### PR TITLE
introduce composer to sugarcrm 6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "vendor-dir": "include/vendors"
+  },
+  "require": {
+  },
+  "autoload": {
+    "psr-4": {
+      "Sugarcrm\\": "include/sugarcrm"
+    }
+  }
+}

--- a/include/entryPoint.php
+++ b/include/entryPoint.php
@@ -152,6 +152,9 @@ require_once('include/modules.php'); // provides $moduleList, $beanList, $beanFi
 
 require('include/utils/autoloader.php');
 spl_autoload_register(array('SugarAutoLoader', 'autoload'));
+if (file_exists('include/composer/vendor/autoload.php')) {
+    require_once('include/composer/vendor/autoload.php');
+}
 require_once('data/SugarBean.php');
 require_once('include/utils/mvc_utils.php');
 require('include/SugarObjects/LanguageManager.php');


### PR DESCRIPTION
- introduces composer
- introduces psr-4 autoloading for Sugar stuff and proper namespacing
- doesn't break backward compatibility
- reduces unnecessary "requre" directives and allow easier refactoring
- allows to update in future old vendors software like Zend libraries, recaptcha, tcpdf and so on & move it to the vendor dir. 