### PR TITLE
Escape hyphen so it is interpreted as a literal rather than meta-character

### DIFF
--- a/include/SugarCharts/JsChart.php
+++ b/include/SugarCharts/JsChart.php
@@ -712,7 +712,7 @@ class JsChart extends SugarChart {
 		$replacement = array();
 		$content = file_get_contents($xmlFile);
 		$content = $GLOBALS['locale']->translateCharset($content,'UTF-16LE', 'UTF-8');
-		$pattern[] = '/\<link\>([a-zA-Z0-9#?&%.;\[\]\/=+_-\s]+)\<\/link\>/e';
+		$pattern[] = '/\<link\>([a-zA-Z0-9#?&%.;\[\]\/=+_\-\s]+)\<\/link\>/e';
 		$replacement[] = "'<link>'.urlencode(\"$1\").'</link>'";
 //		$pattern[] = '/NULL/e';
 //		$replacement[] = "";


### PR DESCRIPTION
The error below appears when libpcre3 v8.39 is being used:
```
PHP Warning: preg_replace_callback(): Compilation failed: invalid range in character class at offset 66 in include/SugarCharts/JsChart.php on line 715
```
This is because hyphen needs to be at first or last place in character class or it should be escaped. Older versions of libpcre3 (i.e v8.31) don't fail as they should because of a bug.