### PR TITLE
soap,json_server: honor php.ini's error_reporting

### DIFF
--- a/json_server.php
+++ b/json_server.php
@@ -297,7 +297,8 @@ function construct_where(&$query_obj, $table='',$module=null)
 ///////////////////////////////////////////////////////////////////////////////
 ////	JSON SERVER HANDLER LOGIC
 //ignore notices
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
+$old_error_reporting = error_reporting();
+error_reporting($old_error_reporting & ~E_NOTICE & ~E_STRICT);
 ob_start();
 insert_charset_header();
 global $sugar_config;

--- a/soap.php
+++ b/soap.php
@@ -48,7 +48,8 @@ require_once('modules/Opportunities/Opportunity.php');
 require_once('service/core/SoapHelperWebService.php');
 require_once('modules/Cases/Case.php');
 //ignore notices
-error_reporting(E_ALL ^ E_NOTICE);
+$old_error_reporting = error_reporting();
+error_reporting($old_error_reporting & ~E_NOTICE & ~E_STRICT);
 
 
 global $HTTP_RAW_POST_DATA;


### PR DESCRIPTION
Because the originally code used `E_ALL` rather than the pre-existing `error_reporting` value, it will actually **reenable** message types that were disabled in php.ini, resulting in spamming the logs with possibly undesired E_STRICT messages, warnings, etc.