### PR TITLE
Incomplete css property display:;

### DIFF
--- a/include/MySugar/tpls/addDashletsDialog.tpl
+++ b/include/MySugar/tpls/addDashletsDialog.tpl
@@ -62,9 +62,9 @@
 {/if}
 
 {if $moduleName == 'Home'}
-<div id="moduleDashlets" style="height:400px;display:;">
+<div id="moduleDashlets" style="height:400px;">
 	<h3>{sugar_translate label='LBL_MODULES' module='Home'}</h3>
-	<div id="moduleDashletsList" style="height:394px;overflow:auto;display:;">
+	<div id="moduleDashletsList" style="height:394px;overflow:auto;">
 	<table width="95%">
 		{counter assign=rowCounter start=0 print=false}
 		{foreach from=$modules item=module}


### PR DESCRIPTION
Can remove it complete, as syntax is wrong, it is unneeded.
"display:;"